### PR TITLE
PS-A: reduce reference keplers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ cache
 
 # model temporary files
 real_estate/results/
+*/main_safe.py

--- a/city_modeller/config/config_commune_av.json
+++ b/city_modeller/config/config_commune_av.json
@@ -8,8 +8,8 @@
                     "id": "s6rv38u",
                     "type": "geojson",
                     "config": {
-                        "dataId": "data",
-                        "label": "data",
+                        "dataId": "data_0",
+                        "label": "data_0",
                         "color": [
                             221,
                             178,

--- a/city_modeller/config/config_commune_av.json
+++ b/city_modeller/config/config_commune_av.json
@@ -8,8 +8,8 @@
                     "id": "s6rv38u",
                     "type": "geojson",
                     "config": {
-                        "dataId": "data_0",
-                        "label": "data_0",
+                        "dataId": "commune_availability",
+                        "label": "commune_availability",
                         "color": [
                             221,
                             178,

--- a/city_modeller/config/config_neigh_av.json
+++ b/city_modeller/config/config_neigh_av.json
@@ -8,8 +8,8 @@
                     "id": "3eczkr",
                     "type": "geojson",
                     "config": {
-                        "dataId": "data",
-                        "label": "data",
+                        "dataId": "data_0",
+                        "label": "data_0",
                         "color": [
                             255,
                             153,

--- a/city_modeller/config/config_neigh_av.json
+++ b/city_modeller/config/config_neigh_av.json
@@ -8,8 +8,8 @@
                     "id": "3eczkr",
                     "type": "geojson",
                     "config": {
-                        "dataId": "data_0",
-                        "label": "data_0",
+                        "dataId": "neighborhood_availability",
+                        "label": "neighborhood_availability",
                         "color": [
                             255,
                             153,

--- a/city_modeller/config/config_radio_av.json
+++ b/city_modeller/config/config_radio_av.json
@@ -8,8 +8,8 @@
                     "id": "r9mrfac",
                     "type": "geojson",
                     "config": {
-                        "dataId": "data",
-                        "label": "data",
+                        "dataId": "data_0",
+                        "label": "data_0",
                         "color": [
                             255,
                             203,

--- a/city_modeller/config/public_spaces.json
+++ b/city_modeller/config/public_spaces.json
@@ -8,8 +8,8 @@
                     "id": "0gw9qyb",
                     "type": "geojson",
                     "config": {
-                        "dataId": "data",
-                        "label": "data",
+                        "dataId": "data_0",
+                        "label": "data_0",
                         "color": [
                             77,
                             193,

--- a/city_modeller/config/public_spaces.json
+++ b/city_modeller/config/public_spaces.json
@@ -8,8 +8,8 @@
                     "id": "0gw9qyb",
                     "type": "geojson",
                     "config": {
-                        "dataId": "data_0",
-                        "label": "data_0",
+                        "dataId": "public_spaces",
+                        "label": "public_spaces",
                         "color": [
                             77,
                             193,

--- a/city_modeller/config/urban_services/isochrones.json
+++ b/city_modeller/config/urban_services/isochrones.json
@@ -8,8 +8,8 @@
                     "id": "0gw9qyb",
                     "type": "geojson",
                     "config": {
-                        "dataId": "data",
-                        "label": "data",
+                        "dataId": "data_0",
+                        "label": "data_0",
                         "color": [
                             77,
                             193,

--- a/city_modeller/config/urban_services/urban_services.json
+++ b/city_modeller/config/urban_services/urban_services.json
@@ -8,8 +8,8 @@
                     "id": "0gw9qyb",
                     "type": "geojson",
                     "config": {
-                        "dataId": "data",
-                        "label": "data",
+                        "dataId": "data_0",
+                        "label": "data_0",
                         "color": [
                             77,
                             193,

--- a/city_modeller/utils.py
+++ b/city_modeller/utils.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 from numbers import Number
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 import geopandas as gpd
 import pandas as pd
@@ -185,7 +185,7 @@ def kepler_df(gdf: gpd.GeoDataFrame) -> list[dict[str, Any]]:
 
 def plot_kepler(
     data: gpd.GeoDataFrame | List[gpd.GeoDataFrame],
-    config: dict,
+    config: Dict[str, Any],
     names: Optional[List[str]] = None,
 ) -> None:
     if isinstance(data, gpd.GeoDataFrame):

--- a/city_modeller/utils.py
+++ b/city_modeller/utils.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 from numbers import Number
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, List, Optional
 
 import geopandas as gpd
 import pandas as pd
@@ -183,11 +183,20 @@ def kepler_df(gdf: gpd.GeoDataFrame) -> list[dict[str, Any]]:
     return df.to_dict("split")
 
 
-def plot_kepler(data: gpd.GeoDataFrame, config: dict) -> None:
-    data_ = kepler_df(data)
-    kepler = KeplerGl(height=500, data={"data": data_}, config=config)
+def plot_kepler(
+    data: gpd.GeoDataFrame | List[gpd.GeoDataFrame],
+    config: dict,
+    names: Optional[List[str]] = None,
+) -> None:
+    if isinstance(data, gpd.GeoDataFrame):
+        data = [data]
+    if names is None:
+        names = [f"data_{idx}" for idx in range(len(data))]
+    kepler = KeplerGl(height=500, config=config)
+    for datum, name in zip(data, names):
+        datum_ = kepler_df(datum)
+        kepler.add_data(data=datum_, name=name)
     keplergl_static(kepler)
-    kepler.add_data(data=data_)
 
 
 def gdf_diff(


### PR DESCRIPTION
No hace falta mirar el código, sólo probalo y decime si es lo que tenías en mente. No hice 4 en 1, hice 2 en 1 simplificando 1 (o sea, ahora no tenemos el mapa de T0, y elegimos qué availability ver en el background). Usar los dos availabilities juntos es un colorinche horrible imparseable, esto es una solución intermedia, aunque quizás hay que repensar la color scale de availability.